### PR TITLE
Domains link fix

### DIFF
--- a/shpd/static/app/layout/dashboard.html
+++ b/shpd/static/app/layout/dashboard.html
@@ -3,7 +3,7 @@
         <a ui-sref="dashboard.domains" class="title item" id="logo">
             shpd.io
         </a>
-        <a ui-sref="dashboard" ui-sref-active="active" class="title item">
+        <a ui-sref="dashboard.domains" ui-sref-active="active" class="title item">
             <i class="browser icon"></i> Domains
         </a>
         <div class="ui right inverted menu">


### PR DESCRIPTION
Fix for error:
```
Error: Cannot transition to abstract state 'dashboard'
    at Object.x.transitionTo (angular-ui-router.min.js:7)
    at Object.x.go (angular-ui-router.min.js:7)
    at angular-ui-router.min.js:7
    at angular.js:16299
    at e (angular.js:4924)
    at angular.js:5312
```